### PR TITLE
Multi Profile 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+.pytest_cache
+.vscode

--- a/README.md
+++ b/README.md
@@ -41,9 +41,14 @@ partner = partner-name
 bucket = your-space
 upload_prefix = in
 
+# this is the default profile
 [aws]
 aws_access_key_id = your_key_id
 aws_secret_access_key = your_secret_key
+
+[dev]
+aws_access_key_id = your_key_dev_id
+aws_secret_access_key = your_dev_secret_key
 ```
 
 Usage

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,10 @@ def find_version(*file_paths):
 requires = [
     'docopt==0.6.2',
     'boto3==1.4.4',
-    'configparser==3.5.0',
-    'pytest==3.7.2',
+    'configparser==3.5.0'
+]
+
+test_requires = [
     'mock==2.0.0'
 ]
 
@@ -61,6 +63,7 @@ setup_options = dict(
     },
     packages=find_packages(exclude=['tests*']),
     install_requires=requires,
+    test_requires=test_requires,
     zip_safe=False,
     license="BSD",
     classifiers=list((

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,9 @@ def find_version(*file_paths):
 requires = [
     'docopt==0.6.2',
     'boto3==1.4.4',
-    'configparser==3.5.0'
+    'configparser==3.5.0',
+    'pytest==3.7.2',
+    'mock==2.0.0'
 ]
 
 setup_options = dict(

--- a/tests/test_wanna.py
+++ b/tests/test_wanna.py
@@ -1,6 +1,7 @@
 from wanna import Transfer
 from wanna.vendors.aws import _AWS
-
+from mock import Mock, MagicMock, patch
+import configparser
 
 def test_aws():
     vendor = _AWS()
@@ -10,3 +11,17 @@ def test_aws():
 def test_transfer():
     t = Transfer()
     assert hasattr(t, 'download_file')
+
+def test_default_profile():
+    with patch.object(configparser.ConfigParser, 'get', return_value="0000") as cfg_get_mocked:
+        t = Transfer()
+
+        cfg_get_mocked.assert_any_call('aws', 'aws_access_key_id', fallback='missing')
+        cfg_get_mocked.assert_any_call('aws', 'aws_secret_access_key', fallback='missing')
+
+def test_named_profile():
+    with patch.object(configparser.ConfigParser, 'get', return_value="0000") as cfg_get_mocked:
+        t = Transfer(profile='partner')
+
+        cfg_get_mocked.assert_any_call('partner', 'aws_access_key_id', fallback='missing')
+        cfg_get_mocked.assert_any_call('partner', 'aws_secret_access_key', fallback='missing')

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,5 @@ envlist = py27, py36, pypy
 [testenv]
 deps =
     pytest
+    mock
 commands = py.test

--- a/wanna/__init__.py
+++ b/wanna/__init__.py
@@ -12,7 +12,7 @@ ALIASES = {
 }
 
 
-def setup_vendor(vendor_str, bucket=None, use_encryption=True, ignore_prefix=False, **other):
+def setup_vendor(vendor_str, bucket=None, use_encryption=True, ignore_prefix=False, profile=None, **other):
     """Setup vendor from the given string and params"""
     vendor = vendor_str.lower()
     try:
@@ -20,11 +20,11 @@ def setup_vendor(vendor_str, bucket=None, use_encryption=True, ignore_prefix=Fal
     except KeyError:
         raise ValueError('datacenter: {}, is not supported'.format(vendor))
     return vendor(
-        bucket=bucket, use_encryption=use_encryption, ignore_prefix=ignore_prefix, **other)
+        bucket=bucket, use_encryption=use_encryption, ignore_prefix=ignore_prefix, profile=profile, **other)
 
 
-def Transfer(vendor='aws', bucket=None, use_encrpytion=True, ignore_prefix=True):
+def Transfer(vendor='aws', bucket=None, use_encrpytion=True, ignore_prefix=True, profile=None):
     """A proxy to vendor"""
     return setup_vendor(
-        vendor, bucket=bucket, use_encryption=use_encrpytion, ignore_prefix=ignore_prefix
+        vendor, bucket=bucket, use_encryption=use_encrpytion, ignore_prefix=ignore_prefix, profile=profile
     )

--- a/wanna/entry_points/wannacli.py
+++ b/wanna/entry_points/wannacli.py
@@ -3,15 +3,20 @@
 
 Usage:
   wanna upload PATH [--no-encrypt] [--no-progress] [--ignore-prefix]
-                    [--checksum] [--datacenter=<aws>] [--bucket=<credentials>] [-v | -vv] [-H | --human]
+                    [--checksum] [--datacenter=<aws>] [--bucket=<credentials>] [-v | -vv] [-H | --human] 
+                    [--profile=<name>]
   wanna download PATH [DST] [--no-decrypt] [--no-progress] [--checksum]
                             [--datacenter=<aws>]  [--bucket=<credentials>] [--ignore-prefix] [-v | -vv] [-H | --human]
+                            [--profile=<name>]
   wanna delete PATH [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv]
+                    [--profile=<name>]
   wanna search TERM [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv]
+                    [--profile=<name>]
   wanna rename OLD NEW [--ignore-prefix] [--datacenter=<aws>] [--no-encrypt]  [--bucket=<credentials>] [-v | -vv]
-  wanna status PATH [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv]
-  wanna generate_secret [-v | -vv]
-  wanna ls [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv] [-H | --human]
+                       [--profile=<name>]
+  wanna status PATH [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv] [--profile=<name>]
+  wanna generate_secret [-v | -vv] [--profile=<name>]
+  wanna ls [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv] [-H | --human] [--profile=<name>]
   wanna (-h | --help)
   wanna --version
 
@@ -23,6 +28,7 @@ Options:
   --no-encrypt   Do not encrypt at rest.
   --no-decrypt   Do not decrypt in transit.
   --ignore-prefix  Ignore all prefixes
+  --profile=<name>  Use a named profile [default: aws]
   --datacenter=<name>  Cloud provider [default: aws]
   --bucket=<name>  Bucket name [default: credentials]
 """
@@ -65,6 +71,8 @@ def _handle(args):
         term = args['TERM']
     vendor = args['--datacenter']
     ignore_prefix = args['--ignore-prefix']
+    
+    profile = args['--profile'] if args['--profile'] else None
     bucket = None if args['--bucket'] == 'credentials' else args['--bucket']
     humanized = any((args['-H'], args['--human']))
     args = locals()

--- a/wanna/settings.py
+++ b/wanna/settings.py
@@ -14,7 +14,7 @@ class Config(object):
     BUCKET = 'mtp-cloudstorage'
     IGNORE_PREFIX = False
 
-    def __init__(self, vendor):
+    def __init__(self, vendor, profile=None):
         config = configparser.ConfigParser()
         config.read(os.path.expanduser('~/.wanna/credentials'))
 
@@ -22,7 +22,7 @@ class Config(object):
         self.ENCRYPTION_KEY = bytes(bytearray.fromhex(config.get('default', 'encryption_key', fallback='0000')))
         self.UPLOAD_PREFIX = config.get('default', 'upload_prefix', fallback='not-set')
         self.BUCKET = config.get('default', 'bucket', fallback=self.BUCKET)
-        self.VENDOR = DATACENTERS[vendor.name.lower()](config)
+        self.VENDOR = DATACENTERS[vendor.name.lower()](config, profile)
 
         ignore_prefix = config.get('default', 'ignore_prefix', fallback=False)
 
@@ -31,9 +31,9 @@ class Config(object):
 
 class AWS(object):
     """Aws specific settings"""
-    def __init__(self, cfg):
-        self.API_KEY = cfg.get('aws', 'aws_access_key_id', fallback='missing')
-        self.API_SECRET = cfg.get('aws', 'aws_secret_access_key', fallback='missing')
+    def __init__(self, cfg, profile=None):
+        self.API_KEY = cfg.get(profile if profile else 'aws', 'aws_access_key_id', fallback='missing')
+        self.API_SECRET = cfg.get(profile if profile else 'aws', 'aws_secret_access_key', fallback='missing')
 
 
 DATACENTERS = {

--- a/wanna/upload/__init__.py
+++ b/wanna/upload/__init__.py
@@ -11,7 +11,7 @@ uploads to the cloud. It handles several things for the user:
 
 def upload_files(
         path, vendor, bucket=None,
-        use_encryption=True, add_checksum=False, progress=False, prefix=None, ignore_prefix=False, humanized=False):
+        use_encryption=True, add_checksum=False, progress=False, prefix=None, ignore_prefix=False, humanized=False, **other):
     """Uploads file to the cloud.
 
     Args:
@@ -25,5 +25,5 @@ def upload_files(
         tuple - confirmation(s) from the vendor
     """
     from wanna import setup_vendor
-    vendor = setup_vendor(vendor, bucket=bucket, use_encryption=use_encryption, ignore_prefix=ignore_prefix, humanized=humanized)
+    vendor = setup_vendor(vendor, bucket=bucket, use_encryption=use_encryption, ignore_prefix=ignore_prefix, humanized=humanized, **other)
     vendor.upload_files(path, add_checksum=add_checksum, progress=progress)

--- a/wanna/vendors/aws/__init__.py
+++ b/wanna/vendors/aws/__init__.py
@@ -30,7 +30,7 @@ LOG = logging.getLogger('wanna:aws')
 
 
 class _AWS(object):
-    """AWS s3 service"""
+    """AWS S3 service"""
     hash_checksum = '.md5'
     signature_version = 's3v4'
     region_name = 'eu-central-1'
@@ -50,8 +50,8 @@ class _AWS(object):
             'config': BotoConfig(signature_version=self.signature_version, region_name=self.region_name)
         }
 
-    def __init__(self, bucket=None, use_encryption=True, ignore_prefix=False, humanized=False):
-        config = Config(self)
+    def __init__(self, bucket=None, use_encryption=True, ignore_prefix=False, humanized=False, profile=None):
+        config = Config(self, profile=profile)
         self._bucket = config.BUCKET if not bucket else bucket
         self._prefix = os.path.join(config.UPLOAD_PREFIX, config.PARTNER_NAME)
         self._encrypt = use_encryption


### PR DESCRIPTION
Allow multiple named profiles to be specified in the wanna-transfer credentials file.

_~/.wanna/credentials_
```ini
# default aws profile
[aws]
aws_access_key_id = your_key_id
aws_secret_access_key = your_secret_key

# named profile
[dev]
aws_access_key_id = your_key_dev_id
aws_secret_access_key = your_dev_secret_key
```


Switching profiles is possible either by passing the profile name in the constructor `Transfer(profile='dev')`, or through the CLI, using the `--profile=dev` flag.