### PR TITLE
pass ignore_prefix to get_object_size

### DIFF
--- a/wanna/vendors/aws/__init__.py
+++ b/wanna/vendors/aws/__init__.py
@@ -224,7 +224,7 @@ class _AWS(object):
         progress_callback = (
             ProgressPercentage(
                 local,
-                size=self.get_object_size(key, encryption_key=encryption_key),
+                size=self.get_object_size(key, encryption_key=encryption_key, ignore_prefix=ignore_prefix),
                 humanized=self._humanized,
             )
             if progress


### PR DESCRIPTION
`ignore_prefix` was passed inconsistently causing a name mismatch and a Not Found error when `progress` flag was set.