### PR TITLE
allow identical search #2

### DIFF
--- a/wanna/__init__.py
+++ b/wanna/__init__.py
@@ -1,6 +1,6 @@
 from wanna.vendors.aws import _AWS
 
-__version__ = '0.1.9'
+__version__ = '0.2.0'
 
 ALIASES = {
     "s3": _AWS,

--- a/wanna/entry_points/wannacli.py
+++ b/wanna/entry_points/wannacli.py
@@ -12,6 +12,8 @@ Usage:
                     [--profile=<name>]
   wanna search TERM [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv]
                     [--profile=<name>]
+  wanna fsearch TERM [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv]
+                    [--profile=<name>]
   wanna rename OLD NEW [--ignore-prefix] [--datacenter=<aws>] [--no-encrypt]  [--bucket=<credentials>] [-v | -vv]
                        [--profile=<name>]
   wanna status PATH [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv] [--profile=<name>]
@@ -105,9 +107,9 @@ def handle_rename(args):
     print("Done!")
 
 
-def handle_search(args):
+def handle_search(args, fuzzy=False):
     kwargs = _handle(args)
-    for el in search_files(**kwargs):
+    for el in search_files(fuzzy=fuzzy,**kwargs):
         print(el)
 
 
@@ -179,6 +181,9 @@ def main():
 
     if args["search"] is True:
         handle_search(args)
+
+    if args["fsearch"] is True:
+        handle_search(args, fuzzy=True)
 
     if args["rename"] is True:
         handle_rename(args)

--- a/wanna/entry_points/wannacli.py
+++ b/wanna/entry_points/wannacli.py
@@ -11,9 +11,7 @@ Usage:
   wanna delete PATH [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv]
                     [--profile=<name>]
   wanna search TERM [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv]
-                    [--profile=<name>]
-  wanna fsearch TERM [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv]
-                    [--profile=<name>]
+                    [--profile=<name>] [--fuzzy]
   wanna rename OLD NEW [--ignore-prefix] [--datacenter=<aws>] [--no-encrypt]  [--bucket=<credentials>] [-v | -vv]
                        [--profile=<name>]
   wanna status PATH [--ignore-prefix] [--datacenter=<aws>]  [--bucket=<credentials>] [-v | -vv] [--profile=<name>]
@@ -71,6 +69,9 @@ def _handle(args):
         new = args["NEW"]
     if args["search"]:
         term = args["TERM"]
+        fuzzy = False
+        if args["--fuzzy"]:
+            fuzzy = True
     vendor = args["--datacenter"]
     ignore_prefix = args["--ignore-prefix"]
 
@@ -107,9 +108,9 @@ def handle_rename(args):
     print("Done!")
 
 
-def handle_search(args, fuzzy=False):
+def handle_search(args):
     kwargs = _handle(args)
-    for el in search_files(fuzzy=fuzzy,**kwargs):
+    for el in search_files(**kwargs):
         print(el)
 
 
@@ -181,9 +182,6 @@ def main():
 
     if args["search"] is True:
         handle_search(args)
-
-    if args["fsearch"] is True:
-        handle_search(args, fuzzy=True)
 
     if args["rename"] is True:
         handle_rename(args)

--- a/wanna/misc/__init__.py
+++ b/wanna/misc/__init__.py
@@ -9,9 +9,9 @@ def delete_file(vendor, path, **kwargs):
     return vendor.delete_file(path)
 
 
-def search_files(vendor, term, **kwargs):
+def search_files(vendor, term, fuzzy=False, **kwargs):
     vendor = setup_vendor(vendor, **kwargs)
-    return vendor.search(term)
+    return vendor.search(term, fuzzy)
 
 
 def rename_file(vendor, old, new, **kwargs):

--- a/wanna/misc/__init__.py
+++ b/wanna/misc/__init__.py
@@ -9,7 +9,7 @@ def delete_file(vendor, path, **kwargs):
     return vendor.delete_file(path)
 
 
-def search_files(vendor, term, fuzzy=False, **kwargs):
+def search_files(vendor, term, fuzzy, **kwargs):
     vendor = setup_vendor(vendor, **kwargs)
     return vendor.search(term, fuzzy)
 

--- a/wanna/utils.py
+++ b/wanna/utils.py
@@ -43,12 +43,13 @@ def humanize(value, binary=True, format="%.1f"):
     return (format + " %s") % ((base * bytes / unit), s)
 
 
-def fuzzyfinder(input, collection, accessor=lambda x: x):
+def finder(input, collection, fuzzy=False, accessor=lambda x: x):
     """
     Args:
         input (str): A partial string which is typically entered by a user.
         collection (iterable): A collection of strings which will be filtered
              based on the `input`.
+        fuzzy (bool): perform a fuzzy search (default=False)
 
     Returns:
         suggestions (generator): A generator object that produces a list of
@@ -56,8 +57,10 @@ def fuzzyfinder(input, collection, accessor=lambda x: x):
     """
     suggestions = []
     input = str(input) if not isinstance(input, str) else input
-    pat = ".*?".join(map(re.escape, input))
-    regex = re.compile(pat)
+    pat = input
+    if fuzzy:
+        pat = ".*?".join(map(re.escape, input))
+    regex = re.compile(pat, re.IGNORECASE)
     for item in collection:
         r = regex.search(accessor(item))
         if r:

--- a/wanna/vendors/aws/__init__.py
+++ b/wanna/vendors/aws/__init__.py
@@ -14,7 +14,7 @@ from wanna.utils import md5sum
 from wanna.utils import ProgressPercentage
 from wanna.utils import ignore_ctrl_c
 from wanna.utils import touch
-from wanna.utils import fuzzyfinder
+from wanna.utils import finder
 
 from wanna.settings import Config
 
@@ -166,10 +166,10 @@ class _AWS(object):
             if add_checksum:
                 self.upload_checksum(item, ignore_prefix=ignore_prefix, prefix=prefix)
 
-    def search(self, term):
-        """Fuzzy search for the object(s) using given term"""
+    def search(self, term, fuzzy=False):
+        """Identical or Fuzzy search for the object(s) using given term"""
         bucket = self.resource.Bucket(self._bucket)
-        for obj in fuzzyfinder(term, (obj.key for obj in bucket.objects.all())):
+        for obj in finder(term, (obj.key for obj in bucket.objects.all()), fuzzy=fuzzy):
             yield obj
 
     def rename_object(self, old_prefix, new_prefix, encryption_key=None):


### PR DESCRIPTION
1. init: update version to 0.2.0
2. wannacli:
 - new term fsearch for the original search (i.e. fuzzy search)
 - new argument in search method to distinguish identical search and fuzzy search
 - update doc
3. add the argument fuzzy in all downstream methods
4. utils:
 - change method fuzzyfinder to finder with fuzzy argument
 - add either identical or fuzzy pattern