### PR TITLE
boto3==1.4.4 => boto3~=1.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-requires = ["docopt==0.6.2", "boto3==1.4.4", "configparser==3.5.0"]
+requires = ["docopt==0.6.2", "boto3~=1.9", "configparser==3.5.0"]
 
 test_requires = [
     'mock==2.0.0'


### PR DESCRIPTION
boto3 [v1.4.4 was released 16 Jan 2017](https://github.com/boto/boto3/releases/tag/1.4.4) so an upgrade was overdue as downstream packages that depend on boto3 have deprecated older versions